### PR TITLE
the CronJob API graduated to GA in batch/v1

### DIFF
--- a/rclone.yaml
+++ b/rclone.yaml
@@ -14,7 +14,7 @@ metadata:
     openshift.io/provider-display-name: CSC
   name: rclone
 objects:
-- apiVersion: batch/v1beta1
+- apiVersion: batch/v1
   kind: CronJob
   metadata:
     labels:


### PR DESCRIPTION
CronJob moves from batch/v1beta1 to batch/v1